### PR TITLE
Update IVS release to 1.3.2

### DIFF
--- a/basicplayback/build.gradle
+++ b/basicplayback/build.gradle
@@ -28,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:ivs-player:1.3.0'
+    implementation 'com.amazonaws:ivs-player:1.3.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.core:core-ktx:1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
     dependencies {
@@ -14,7 +13,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }

--- a/customui/dependencies.gradle
+++ b/customui/dependencies.gradle
@@ -11,7 +11,7 @@ def daggerVersion = '2.27'
 dependencies {
 
     // Libraries
-    implementation 'com.amazonaws:ivs-player:1.3.0'
+    implementation 'com.amazonaws:ivs-player:1.3.2'
 
     // Material design
     implementation "com.google.android.material:material:$materialDesignVersion"

--- a/quizdemo/dependencies.gradle
+++ b/quizdemo/dependencies.gradle
@@ -12,7 +12,7 @@ def gsonVersion = '2.8.6'
 dependencies {
 
     // Libraries
-    implementation 'com.amazonaws:ivs-player:1.3.0'
+    implementation 'com.amazonaws:ivs-player:1.3.2'
 
     // Material design
     implementation "com.google.android.material:material:$materialDesignVersion"


### PR DESCRIPTION
*Description of changes:*
Update IVS release to 1.3.2, and removed jcenter from repository since it is being retired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
