### PR TITLE
Update Android SDK to 33, various dependencies

### DIFF
--- a/basicplayback/build.gradle
+++ b/basicplayback/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.amazonaws.ivs.player.basicplayback"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }
@@ -18,11 +18,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.amazonaws.ivs.player.basicplayback'
 }
 
 dependencies {
     implementation "com.amazonaws:ivs-player:$player_version"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.core:core-ktx:1.0.2'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'

--- a/basicplayback/src/main/AndroidManifest.xml
+++ b/basicplayback/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.amazonaws.ivs.player.basicplayback">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"
@@ -10,6 +9,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity android:name=".MainActivity"
+            android:exported="true"
             android:configChanges="orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.4.31'
+    ext.kotlin_version = '1.7.20'
     ext.player_version = findProperty("playerVersion") ?: '1.13.0'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/customui/build.gradle
+++ b/customui/build.gradle
@@ -5,12 +5,16 @@ apply plugin: 'kotlin-kapt'
 apply from: 'dependencies.gradle'
 
 android {
-    compileSdkVersion 30
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.amazonaws.ivs.player.customui"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
@@ -36,4 +40,5 @@ android {
     dataBinding {
         enabled = true
     }
+    namespace 'com.amazonaws.ivs.player.customui'
 }

--- a/customui/dependencies.gradle
+++ b/customui/dependencies.gradle
@@ -1,12 +1,12 @@
-def appCompatVersion = '1.1.0'
-def coreVersion = '1.2.0'
-def constraintLayoutVersion = '1.1.3'
-def materialDesignVersion = '1.1.0'
-def recyclerViewVersion = '1.1.0'
-def roomVersion = '2.2.5'
+def appCompatVersion = '1.5.1'
+def coreVersion = '1.9.0'
+def constraintLayoutVersion = '2.1.4'
+def materialDesignVersion = '1.7.0'
+def recyclerViewVersion = '1.2.1'
+def roomVersion = '2.4.3'
 def cardViewVersion = '1.0.0'
-def lifecycleVersion = '2.2.0'
-def daggerVersion = '2.27'
+def lifecycleVersion = '2.5.1'
+def daggerVersion = '2.43.2'
 
 dependencies {
 
@@ -19,7 +19,6 @@ dependencies {
     // Android
     implementation "androidx.recyclerview:recyclerview:$recyclerViewVersion"
     implementation "androidx.cardview:cardview:$cardViewVersion"
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
 
@@ -33,7 +32,6 @@ dependencies {
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
     implementation "androidx.core:core-ktx:$coreVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"

--- a/customui/src/main/AndroidManifest.xml
+++ b/customui/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.amazonaws.ivs.player.customui">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"
@@ -13,6 +12,7 @@
 
         <activity
             android:name="com.amazonaws.ivs.player.customui.activities.MainActivity"
+            android:exported="true"
             android:configChanges="orientation|screenLayout|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/customui/src/main/java/com/amazonaws/ivs/player/customui/activities/MainActivity.kt
+++ b/customui/src/main/java/com/amazonaws/ivs/player/customui/activities/MainActivity.kt
@@ -4,11 +4,13 @@ import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 import android.view.View
 import android.widget.SeekBar
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.databinding.DataBindingUtil
@@ -42,7 +44,7 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
     private val rateDialog by lazy { RateDialog(this, viewModel) }
     private val sourceDialog by lazy { SourceDialog(this, viewModel) }
 
-    private val timerHandler = Handler()
+    private val timerHandler = Handler(Looper.getMainLooper())
     private val timerRunnable = kotlinx.coroutines.Runnable {
         launchMain {
             Log.d(TAG, "Hiding controls")
@@ -190,15 +192,17 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
         initSurface()
         initButtons()
         viewModel.playerStart(surface_view.holder.surface)
-    }
 
-    override fun onBackPressed() {
-        when {
-            qualityDialog.isOpened() -> qualityDialog.dismiss()
-            rateDialog.isOpened() -> rateDialog.dismiss()
-            sourceDialog.isOpened() -> sourceDialog.dismiss()
-            else -> super.onBackPressed()
-        }
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                when {
+                    qualityDialog.isOpened() -> qualityDialog.dismiss()
+                    rateDialog.isOpened() -> rateDialog.dismiss()
+                    sourceDialog.isOpened() -> sourceDialog.dismiss()
+                    else -> finish()
+                }
+            }
+        })
     }
 
     override fun onResume() {
@@ -257,7 +261,7 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
                     viewModel.buttonState.value = PlayingState.PAUSED
                     viewModel.pause()
                 }
-                PlayingState.PAUSED -> {
+                else -> {
                     viewModel.buttonState.value = PlayingState.PLAYING
                     viewModel.play()
                 }

--- a/customui/src/main/java/com/amazonaws/ivs/player/customui/activities/adapters/PlayerOptionAdapter.kt
+++ b/customui/src/main/java/com/amazonaws/ivs/player/customui/activities/adapters/PlayerOptionAdapter.kt
@@ -33,7 +33,7 @@ class PlayerOptionAdapter(
     inner class ViewHolder(val binding: SelectorListItemBinding) : RecyclerView.ViewHolder(binding.root) {
         init {
             itemView.setOnClickListener {
-                callback.onOptionClicked(adapterPosition)
+                callback.onOptionClicked(bindingAdapterPosition)
             }
         }
     }

--- a/customui/src/main/java/com/amazonaws/ivs/player/customui/common/ViewModelExtensions.kt
+++ b/customui/src/main/java/com/amazonaws/ivs/player/customui/common/ViewModelExtensions.kt
@@ -16,7 +16,7 @@ inline fun <reified T : ViewModel> FragmentActivity.lazyViewModel(noinline creat
 }
 
 class BaseViewModelFactory<T>(val creator: () -> T) : ViewModelProvider.Factory {
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         @Suppress("UNCHECKED_CAST")
         return creator() as T
     }

--- a/customui/src/main/java/com/amazonaws/ivs/player/customui/viewModel/MainViewModel.kt
+++ b/customui/src/main/java/com/amazonaws/ivs/player/customui/viewModel/MainViewModel.kt
@@ -3,6 +3,7 @@ package com.amazonaws.ivs.player.customui.viewModel
 import android.app.Application
 import android.net.Uri
 import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.view.Surface
 import androidx.lifecycle.MutableLiveData
@@ -17,7 +18,6 @@ import com.amazonaws.ivs.player.customui.common.enums.PlayingState
 import com.amazonaws.ivs.player.customui.data.LocalCacheProvider
 import com.amazonaws.ivs.player.customui.data.entity.OptionDataItem
 import com.amazonaws.ivs.player.customui.data.entity.SourceDataItem
-import kotlinx.coroutines.flow.collect
 import java.nio.charset.StandardCharsets
 
 class MainViewModel(
@@ -28,7 +28,7 @@ class MainViewModel(
     private var player: MediaPlayer? = null
     private var playerListener: Player.Listener? = null
 
-    private val handler = Handler()
+    private val handler = Handler(Looper.getMainLooper())
     private val updateSeekBarTask = object : Runnable {
         override fun run() {
             progress.value = player?.position?.timeString()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/quizdemo/build.gradle
+++ b/quizdemo/build.gradle
@@ -5,12 +5,16 @@ apply plugin: 'kotlin-kapt'
 apply from: 'dependencies.gradle'
 
 android {
-    compileSdkVersion 30
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.amazonaws.ivs.player.quizdemo"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
@@ -36,4 +40,5 @@ android {
     dataBinding {
         enabled = true
     }
+    namespace 'com.amazonaws.ivs.player.quizdemo'
 }

--- a/quizdemo/dependencies.gradle
+++ b/quizdemo/dependencies.gradle
@@ -1,13 +1,13 @@
-def appCompatVersion = '1.1.0'
-def coreVersion = '1.2.0'
-def constraintLayoutVersion = '1.1.3'
-def materialDesignVersion = '1.1.0'
-def recyclerViewVersion = '1.1.0'
-def roomVersion = '2.2.5'
+def appCompatVersion = '1.5.1'
+def coreVersion = '1.9.0'
+def constraintLayoutVersion = '2.1.4'
+def materialDesignVersion = '1.7.0'
+def recyclerViewVersion = '1.2.1'
+def roomVersion = '2.4.3'
 def cardViewVersion = '1.0.0'
-def lifecycleVersion = '2.2.0'
-def daggerVersion = '2.27'
-def gsonVersion = '2.8.6'
+def lifecycleVersion = '2.5.1'
+def daggerVersion = '2.43.2'
+def gsonVersion = '2.8.9'
 
 dependencies {
 
@@ -20,7 +20,6 @@ dependencies {
     // Android
     implementation "androidx.recyclerview:recyclerview:$recyclerViewVersion"
     implementation "androidx.cardview:cardview:$cardViewVersion"
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
 
@@ -37,7 +36,6 @@ dependencies {
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
     implementation "androidx.core:core-ktx:$coreVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"

--- a/quizdemo/src/main/AndroidManifest.xml
+++ b/quizdemo/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.amazonaws.ivs.player.quizdemo">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name=".App"
@@ -12,6 +11,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".activities.MainActivity"
+            android:exported="true"
             android:configChanges="orientation|screenLayout|screenSize"
             android:windowSoftInputMode="stateHidden">
             <intent-filter>

--- a/quizdemo/src/main/java/com/amazonaws/ivs/player/quizdemo/activities/MainActivity.kt
+++ b/quizdemo/src/main/java/com/amazonaws/ivs/player/quizdemo/activities/MainActivity.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
@@ -89,13 +90,15 @@ class MainActivity : AppCompatActivity(), SurfaceHolder.Callback {
 
         initUi()
         viewModel.playerStart(surface_view.holder.surface)
-    }
 
-    override fun onBackPressed() {
-        when {
-            sourceDialog.isOpened() -> sourceDialog.dismiss()
-            else -> super.onBackPressed()
-        }
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                when {
+                    sourceDialog.isOpened() -> sourceDialog.dismiss()
+                    else -> finish()
+                }
+            }
+        })
     }
 
     override fun onResume() {

--- a/quizdemo/src/main/java/com/amazonaws/ivs/player/quizdemo/common/ViewModelExtensions.kt
+++ b/quizdemo/src/main/java/com/amazonaws/ivs/player/quizdemo/common/ViewModelExtensions.kt
@@ -16,7 +16,7 @@ inline fun <reified T : ViewModel> FragmentActivity.lazyViewModel(noinline creat
 }
 
 class BaseViewModelFactory<T>(val creator: () -> T) : ViewModelProvider.Factory {
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         @Suppress("UNCHECKED_CAST")
         return creator() as T
     }


### PR DESCRIPTION
*Description of changes:*

In order to support building on Apple silicone Macs, the project needed an updated version of the `room` dependency. This version update also required updating Kotlin and Android SDK versions, which deprecated some API usages which were also updated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
