### PR TITLE
Update IVS Player SDK version to 1.29.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
-    ext.default_player_version = "1.28.0"
+    ext.default_player_version = "1.29.0"
     ext.player_version = findProperty("playerVersion") ?: default_player_version
 
     repositories {


### PR DESCRIPTION
Update IVS Player SDK version to 1.29.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
